### PR TITLE
PR with work from 2021/1121

### DIFF
--- a/topics/sami-ethan-talk/deps.edn
+++ b/topics/sami-ethan-talk/deps.edn
@@ -1,12 +1,13 @@
 {:deps      {org.clojure/clojure {:mvn/version "1.10.3"}
-             scicloj/notespace   {:mvn/version "4-alpha-3"}}
+             ;; scicloj/notespace {:mvn/version "4-alpha-13"}
+             aerial.hanami/aerial.hanami {:mvn/version "0.12.9"}
+             org.scicloj/viz.clj {:mvn/version "0.1.1-SNAPSHOT"}
+             scicloj/tablecloth {:mvn/version "6.031"}
+             org.scicloj/tablecloth.time {:mvn/version "1.00-alpha-4-SNAPSHOT"}
+             scicloj/scicloj.ml {:mvn/version "0.1.1"}}
  :aliases {:notespace {:extra-deps {nrepl/nrepl       {:mvn/version "0.8.3"}
                                     cider/cider-nrepl {:mvn/version "0.26.0"}
-                                    scicloj/notespace {:mvn/version "4-alpha-13"}
-                                    aerial.hanami/aerial.hanami {:mvn/version "0.12.9"}
-                                    org.scicloj/viz.clj {:mvn/version "0.1.1-SNAPSHOT"}
-                                    scicloj/tablecloth {:mvn/version "6.031"}
-                                    org.scicloj/tablecloth.time {:mvn/version "1.00-alpha-4-SNAPSHOT"}}
+                                    scicloj/notespace {:mvn/version "4-alpha-13"}}
                        :main-opts  ["-m" "nrepl.cmdline"
                                     "--port" "4444"
                                     "--middleware" "[scicloj.notespace.v4.nrepl/middleware,cider.nrepl/cider-middleware]"

--- a/topics/sami-ethan-talk/deps.edn
+++ b/topics/sami-ethan-talk/deps.edn
@@ -5,7 +5,8 @@
                                     scicloj/notespace {:mvn/version "4-alpha-13"}
                                     aerial.hanami/aerial.hanami {:mvn/version "0.12.9"}
                                     org.scicloj/viz.clj {:mvn/version "0.1.1-SNAPSHOT"}
-                                    scicloj/tablecloth {:mvn/version "6.031"}}
+                                    scicloj/tablecloth {:mvn/version "6.031"}
+                                    org.scicloj/tablecloth.time {:mvn/version "1.00-alpha-4-SNAPSHOT"}}
                        :main-opts  ["-m" "nrepl.cmdline"
                                     "--port" "4444"
                                     "--middleware" "[scicloj.notespace.v4.nrepl/middleware,cider.nrepl/cider-middleware]"

--- a/topics/sami-ethan-talk/src/analysis.clj
+++ b/topics/sami-ethan-talk/src/analysis.clj
@@ -1,0 +1,33 @@
+(ns analysis)
+
+(require '[tablecloth.api :as table]
+         '[scicloj.notespace.v4.api :as notespace])
+
+;; (notespace/restart-events!)
+
+(def messages (table/dataset "prepped-data.csv" {:key-fn keyword}))
+
+(table/head messages)
+
+(table/shape messages)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Splitting
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+(defn our-split [ds]
+  (let [sds (-> ds
+                (table/group-by [:subject])
+                (table/without-grouping-> (table/split :holdout)))
+        select-split (fn [split-name split-ds]
+                      (-> split-ds
+                          (table/without-grouping->
+                           (table/select-rows
+                            (comp (partial = split-name) :$split-name)))
+                          (table/ungroup)))]
+    {:train (select-split :train sds) 
+     :test  (select-split :test sds)}))
+
+(def split-pair
+  (our-split messages))

--- a/topics/sami-ethan-talk/src/fiddle.clj
+++ b/topics/sami-ethan-talk/src/fiddle.clj
@@ -23,12 +23,11 @@
 (-> raw-data first keys)
 
 (def messages (->> raw-data
-                   (map #(select-keys %
-                                      [:subject
-                                       :sender_id
-                                       :timestamp
-                                       :content]))
-                   table/dataset))
+                   (table/dataset)
+                   (table/select-columns [:subject
+                                          :sender_id
+                                          :timestamp
+                                          :content])))
 
 ^kind/dataset
 (table/head messages)

--- a/topics/sami-ethan-talk/src/fiddle.clj
+++ b/topics/sami-ethan-talk/src/fiddle.clj
@@ -101,7 +101,9 @@
                              :local-date-time))
                           :local-date-time
                           (:timestamp %)))
-      (table/add-column :month #(emap time/month :string (:date-time %)))
+      (table/add-column :month #(emap (fn [t] (time/month t {:as-number? true}))
+                                      :int32
+                                      (:date-time %)))
       (table/add-column :year #(emap time/year :int32 (:date-time %)))
       (table/drop-columns
        [:same-sender-as-last?

--- a/topics/sami-ethan-talk/src/fiddle.clj
+++ b/topics/sami-ethan-talk/src/fiddle.clj
@@ -84,10 +84,13 @@
                                 prompt-response-threshold))
       (table/add-column :active?
                         #(emap
-                          (fn [next-response-prompt?]
-                            (if next-response-prompt? true false))
+                          (fn [next-response-prompt? prompt-response?]
+                            (if next-response-prompt?
+                              true
+                              (if prompt-response? true false)))
                           :boolean
-                          (:next-response-prompt? %)))
+                          (:next-response-prompt? %)
+                          (:prompt-response? %)))
       (table/add-column
        :secs-since-diff-sender
        #(map (fn [secs]

--- a/topics/sami-ethan-talk/src/fiddle.clj
+++ b/topics/sami-ethan-talk/src/fiddle.clj
@@ -75,16 +75,9 @@
       (table/add-column :prompt-response?
                         #(fun/< (:secs-since-diff-sender %)
                                 prompt-response-threshold))
-      (table/add-column :next-response-prompt?
+      (table/add-column :active?
                         #(fun/< (fun/shift (:secs-since-diff-sender %) -1)
                                 prompt-response-threshold))
-      (table/add-column :active?
-                        #(tech.v3.datatype/emap
-                          (fn [next-response-prompt?]
-                            (if next-response-prompt? true false))
-                          :boolean
-                         ;; 
-                          (:next-response-prompt? %)))
       (table/add-column
        :secs-since-diff-sender
        #(map (fn [secs]
@@ -94,11 +87,11 @@
        [:same-sender-as-last?
         :secs-since-last
         :secs-since-diff-sender
-        :prompt-response?
-        :next-response-prompt?])
+        :prompt-response?])
       (table/ungroup)))
 
 (require '[scicloj.viz.api :as viz])
+
 (require '[tech.v3.datatype.datetime :as dtype-dt])
 
 (-> messages-active?

--- a/topics/sami-ethan-talk/src/fiddle.clj
+++ b/topics/sami-ethan-talk/src/fiddle.clj
@@ -75,9 +75,16 @@
       (table/add-column :prompt-response?
                         #(fun/< (:secs-since-diff-sender %)
                                 prompt-response-threshold))
-      (table/add-column :active?
+      (table/add-column :next-response-prompt?
                         #(fun/< (fun/shift (:secs-since-diff-sender %) -1)
                                 prompt-response-threshold))
+      (table/add-column :active?
+                        #(tech.v3.datatype/emap
+                          (fn [next-response-prompt?]
+                            (if next-response-prompt? true false))
+                          :boolean
+                         ;; 
+                          (:next-response-prompt? %)))
       (table/add-column
        :secs-since-diff-sender
        #(map (fn [secs]
@@ -87,11 +94,11 @@
        [:same-sender-as-last?
         :secs-since-last
         :secs-since-diff-sender
-        :prompt-response?])
+        :prompt-response?
+        :next-response-prompt?])
       (table/ungroup)))
 
 (require '[scicloj.viz.api :as viz])
-
 (require '[tech.v3.datatype.datetime :as dtype-dt])
 
 (-> messages-active?

--- a/topics/sami-ethan-talk/src/fiddle.clj
+++ b/topics/sami-ethan-talk/src/fiddle.clj
@@ -22,12 +22,12 @@
 
 (-> raw-data first keys)
 
-(def messages (->> raw-data
-                   (table/dataset)
-                   (table/select-columns [:subject
-                                          :sender_id
-                                          :timestamp
-                                          :content])))
+(def messages (-> raw-data
+                  (table/dataset)
+                  (table/select-columns [:subject
+                                         :sender_id
+                                         :timestamp
+                                         :content])))
 
 ^kind/dataset
 (table/head messages)


### PR DESCRIPTION
High level list of changes here:
* Small change to how we filter columns
* Use tablecloth.time to generate time component features
* Move generation of time components into main column/feature generation expression
* Exported this data 
* Added `analysis` namespace
* Train/test split based with data grouped by subject

